### PR TITLE
Add missing Icon to theme.xml

### DIFF
--- a/theme.xml
+++ b/theme.xml
@@ -320,6 +320,7 @@
         <part id="canvas_ne" x="128" y="96" w="16" h="16" />
         <part id="canvas_w" x="96" y="112" w="16" h="16" />
         <part id="canvas_c" x="112" y="112" w="16" h="16" />
+        <part id="canvas_e" x="128" y="112" w="16" h="16" />
         <part id="canvas_sw" x="96" y="128" w="16" h="16" />
         <part id="canvas_s" x="112" y="128" w="16" h="16" />
         <part id="canvas_se" x="128" y="128" w="16" h="16" />


### PR DESCRIPTION
I found the icon that was not applied. 

So I looked it up in the theme.xml file, there was no "canvas_e".

![before](https://github.com/Lyutria/aseprite-studio-theme/assets/91962051/f7a23df1-ee66-4ac1-947e-1f52b5d38738)

```xml
<part id="canvas_e" x="128" y="112" w="16" h="16" />
```

I added the code to the file, and it was applied well.

![after](https://github.com/Lyutria/aseprite-studio-theme/assets/91962051/d4e93a26-dd3a-49e4-b682-dfb7e90f17bd)
